### PR TITLE
Should downgrade numpy

### DIFF
--- a/notebooks/TFLite_Micro_Seq2Seq_LSTM_w_attn_&_bidirectional_encoder.ipynb
+++ b/notebooks/TFLite_Micro_Seq2Seq_LSTM_w_attn_&_bidirectional_encoder.ipynb
@@ -48,7 +48,8 @@
       },
       "source": [
         "!apt-get -qq update && apt-get -qq install xxd\n",
-        "!pip install -q tensorflow==2.1.0"
+        "!pip install -q tensorflow==2.1.0",
+        "!pip install -U numpy==1.18.5"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Probably, colab is no more using the same version of numpy you used before, when executing `encoder_lstm_layer(encoder_embeddings)` the following error come out :
`Cannot convert a symbolic Tensor (bidirectional_2/forward_rnn_4/strided_slice:0) to a numpy array.`